### PR TITLE
Fix 'ARC forbids Objective-C objects in struct` error in HBAstNumber.h

### DIFF
--- a/src/handlebars-objc/ast/expression/HBAstNumber.h
+++ b/src/handlebars-objc/ast/expression/HBAstNumber.h
@@ -31,7 +31,7 @@
 typedef struct HBParserIntegerValue HBParserIntegerValue;
 struct HBParserIntegerValue {
     int value;
-    NSString* source;
+    __unsafe_unretained NSString* source; //Get rid of 'Arc forbids' error
 };
 
 @interface HBAstNumber : HBAstValue


### PR DESCRIPTION
This gets rid of the 'ARC forbids Objective-C objects in struct` error discussed [here](https://github.com/Bertrand/handlebars-objc/issues/15#issuecomment-172317394).

