### PR TITLE
Fix building with Xcode 9.3

### DIFF
--- a/src/handlebars-objc/helpers/HBBuiltinHelpersRegistry.m
+++ b/src/handlebars-objc/helpers/HBBuiltinHelpersRegistry.m
@@ -165,7 +165,7 @@ static HBBuiltinHelpersRegistry* _builtinHelpersRegistry = nil;
             NSMutableString* result = [NSMutableString string];
             for (id key in dictionaryLike) {
                 dictionaryData[@"key"] = key;
-                id statementEvaluation = callingInfo.statements(dictionaryLike[key], dictionaryData);
+                id statementEvaluation = callingInfo.statements(expression[key], dictionaryData);
                 if (statementEvaluation) [result appendString:statementEvaluation];
             }
             [dictionaryData release];


### PR DESCRIPTION
Fixes #20 

The check on line 159 (`[HBHelperUtils isEnumerableByKey:expression]`) already validates that `expression` responds to `objectForKeyedSubscript:`.